### PR TITLE
修改livereload默认host

### DIFF
--- a/lib/livereload.js
+++ b/lib/livereload.js
@@ -11,7 +11,7 @@ var defaultHostname = (function() {
     var detail = net[key];
     Object.keys(detail).every(function(i) {
       var address = String(detail[i].address).trim();
-      if (address && /^\d+(?:\.\d+){3}$/.test(address)) {
+      if (address && /^\d+(?:\.\d+){3}$/.test(address) && address !== '127.0.0.1') {
         ip = address;
       }
       return !ip; // 找到了，则跳出循环


### PR DESCRIPTION
为了方便手机端页面使用livereload功能，建议将默认 host 由 127.0.0.1 换为局域网IP。从大部分使用场景来看本地开发阶段才会使用 livereload功能，因此不会出现安全性问题。即使需要设置为 127.0.0.1 ，也可以通过以下代码设置。

```
var hostname = fis.config.get('livereload.hostname', defaultHostname);
```
