### PR TITLE
使默认host可配置

### DIFF
--- a/lib/livereload.js
+++ b/lib/livereload.js
@@ -7,11 +7,25 @@ var LRPORT;
 var defaultHostname = (function() {
   var ip = false;
   var net = require('os').networkInterfaces();
+  
+  /*
+	获取fis-config.js中配置的默认host规则，可以是字符串或正则，字符串中 * 可以代表任意数字。
+	使用示例：fis.config.set('livereload-iprule', '192.168.*.*')
+	适用场景：机器上安装虚拟机后，会有很多虚拟网卡，默认获取的ip在局域网中访问不到，手机调试时加载不了。
+  */
+  var iprule = fis.config.get('livereload-iprule');
+  if(iprule && typeof(iprule) === 'string'){
+	  iprule = new RegExp('^' + iprule.replace(/\.|\*/g, function(v){
+		  return v === '.'? '\\\.' : '\\\d+'
+	  }) + '$');
+  }else if(!(iprule instanceof RegExp)){
+	  iprule = /^\d+(?:\.\d+){3}$/;
+  }
   Object.keys(net).every(function(key) {
     var detail = net[key];
     Object.keys(detail).every(function(i) {
       var address = String(detail[i].address).trim();
-      if (address && /^\d+(?:\.\d+){3}$/.test(address) && address !== '127.0.0.1') {
+      if (address && iprule.test(address)) {
         ip = address;
       }
       return !ip; // 找到了，则跳出循环


### PR DESCRIPTION
获取fis-config中配置的默认host规则，可以是字符串或正则，字符串中 \* 可以代表任意数字。
使用示例：fis.config.set('livereload-iprule', '192.168._._')
适用场景：机器上安装虚拟机后，会有很多虚拟网卡，默认获取的ip在局域网中访问不到，手机调试时加载不了。
