### PR TITLE
使发布的路径可配置

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ fis-command-release的修改版，减轻命令行输入的负担，使得命令�
 ##fis-conf.js配置方法
 ```js
 //发布路径设置
-fis.media('debug')
+fis.media('prod')
 	.set('release',{
 	    'dir':'output',//release的dest路径，对应命令行的-d/--dest参数
 	    /*'watch':true,//对应命令行的-w参数

--- a/README.md
+++ b/README.md
@@ -1,5 +1,32 @@
-# fis-command-release
+# fiss-command-release
+fis-command-release的修改版，减轻命令行输入的负担，使得命令行的参数都可以在fis-conf.js里面可配置。如果命令行输入了参数，
+则使用命令行传入的参数，如果没有，读取fis-conf.js里面的设置的参数。
 
+##fis-conf.js配置方法
+```js
+//发布路径设置
+fis.media('debug')
+	.set('release',{
+	    'dir':'output',//release的dest路径，对应命令行的-d/--dest参数
+	    /*'watch':true,//对应命令行的-w参数
+	    'live':true,*/ //对应命令行的-L参数
+	    'clean':false, //对应命令行的-c参数
+	    /*'lint':true,*///对应命令行的-l参数
+	    'clear':true //每次release之前是否先清空dest目录
+	});
+
+
+```
+
+使用方法
+```bash
+#后面不需要带-d -w -L -l -c 等参数
+fiss release prod
+
+```
+
+---
+# 下面为原版fis-command-release的reademe内容
 ## Usage
 
      Usage: fis release [media name]

--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ exports.run = function(argv, cli, env) {
 
   // normalize options
   var options = {
-    dest: argv.dest || argv.d || 'preview',
+    dest: argv.dest || argv.d || fis.get('release.dir') || 'preview',
     watch: !!(argv.watch || argv.w),
     live: !!(argv.live || argv.L),
     clean: !!(argv.clean || argv.c),

--- a/index.js
+++ b/index.js
@@ -30,9 +30,10 @@ exports.run = function(argv, cli, env) {
 
   validate(argv);
 
+
   // normalize options
   var options = {
-    dest: argv.dest || argv.d || fis.get('release.dir') || 'preview',
+    dest: argv.dest || argv.d || fis.media().get('release.dir') || 'preview',
     watch: !!(argv.watch || argv.w),
     live: !!(argv.live || argv.L),
     clean: !!(argv.clean || argv.c),

--- a/index.js
+++ b/index.js
@@ -34,13 +34,17 @@ exports.run = function(argv, cli, env) {
   // normalize options
   var options = {
     dest: argv.dest || argv.d || fis.media().get('release.dir') || 'preview',
-    watch: !!(argv.watch || argv.w),
-    live: !!(argv.live || argv.L),
-    clean: !!(argv.clean || argv.c),
+    watch: !!(argv.watch || argv.w || fis.media().get('release.watch')),
+    live: !!(argv.live || argv.L || fis.media().get('release.live')),
+    clean: !!(argv.clean || argv.c || fis.media().get('release.clean')),
     unique: !!(argv.unique || argv.u),
-    useLint: !!(argv.lint || argv.l),
-    verbose: !!argv.verbose
+    useLint: !!(argv.lint || argv.l || fis.media().get('release.lint')),
+    verbose: !!argv.verbose,
+    clear: !!fis.media().get('release.clear')
   };
+
+  //打印出当前relese的各参数
+  fis.log.info('当前release的输出路径为:%s',options.dest);
 
   // enable watch automatically when live is enabled.
   options.live && (options.watch = true);
@@ -70,6 +74,15 @@ exports.run = function(argv, cli, env) {
 
   // watch it?
   options.watch && app.use(watch);
+  //清除dest目录
+  app.use(function(options,next){
+    //clear dest/*
+    if(options.clear && options.dest !== 'preview'){
+    fis.log.info('clear dir %s',options.dest);
+     _.del(options.dest); 
+    }
+    next(null, options);
+  });
   app.use(release);
 
   // 处理 livereload 脚本


### PR DESCRIPTION
获取fis-config中配置的默认release.dir参数，类型是字符串。
使用示例：fis.set('release.dir','output');
适用场景：有的项目的发布路径是固定的，每次发布时不想在命令行输入-d参数来指明发布的路径，也不想再通过deploy插件再更改发布的路径。通过本次修改之后，如果命令行有参数-d/-dest指明发布路径则采用命令行的参数，如果没有去配置文件中配置的发布路径，如果都没有再发布到默认路径。
