### PR TITLE
解决在FIS3 在执行http-push的时候，Webstorm主动保存导致上传中断的bug

### DIFF
--- a/lib/watch.js
+++ b/lib/watch.js
@@ -129,7 +129,7 @@ function watch(options, next) {
 
   var busy = false;
   var timer;
-  var latestTotal;
+  var latestTotal = [];
 
   // 当后续的流程全部跑完后执行。
   function done(error, ret) {


### PR DESCRIPTION
/usr/local/lib/node_modules/yog2/node_modules/fis3-command-release/lib/watch.js:197
    Object.keys(map).forEach(function(subpath) {
           ^

TypeError: Cannot convert undefined or null to object
    at getAffectedFiles (/usr/local/lib/node_modules/yog2/node_modules/fis3-command-release/lib/watch.js:197:12)
    at FSWatcher.<anonymous> (/usr/local/lib/node_modules/yog2/node_modules/fis3-command-release/lib/watch.js:321:35)
    at emitTwo (events.js:106:13)
    at FSWatcher.emit (events.js:191:7)
    at FSWatcher.<anonymous> (/usr/local/lib/node_modules/yog2/node_modules/chokidar/index.js:171:15)
    at FSWatcher._emit (/usr/local/lib/node_modules/yog2/node_modules/chokidar/index.js:212:5)
    at FSWatcher.<anonymous> (/usr/local/lib/node_modules/yog2/node_modules/chokidar/lib/nodefs-handler.js:263:16)
    at FSReqWrap.oncomplete (fs.js:117:15)
