### PR TITLE
给 process 挂载一个 EventEmitter 若不存在，防止 livereload-server-spec 包依赖的 websocket.io-spec 包运行报错

### DIFF
--- a/lib/livereload.js
+++ b/lib/livereload.js
@@ -50,6 +50,21 @@ function makeLiveServer(callback) {
     }
 
     LRPORT = port;
+
+    /**
+     * HACK: 给 process 挂载一个 EventEmitter 若不存在
+     * 防止 livereload-server-spec 包依赖的 websocket.io-spec 包运行报错
+     * 
+     * process.EventEmitter 于 node 6.0.0 开始过时（nodejs/node#5049）
+     * process.EventEmitter 于 node 7.0.0 开始移除（nodejs/node#6862）
+     * 
+     * require('events') 于 io.js 1.0.1 开始直接返回 EventEmitter
+     * 所以可以安全使用 require('events') 挂载 EventEmitter
+     */
+    if (!('EventEmitter' in process)) {
+      process.EventEmitter = require('events')
+    }
+
     var LiveReloadServer = require('livereload-server-spec');
 
     LRServer = new LiveReloadServer({


### PR DESCRIPTION
`防止 livereload-server-spec 包依赖的 websocket.io-spec 包运行报错`

process.EventEmitter 于 node 6.0.0 开始过时（nodejs/node#5049）
process.EventEmitter 于 node 7.0.0 开始移除（nodejs/node#6862）

require('events') 于 io.js 1.0.1 开始直接返回 EventEmitter
所以可以安全使用 require('events') 挂载 EventEmitter