### PR TITLE
如果产出目录在源码目录内，则直接过滤不编译

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,23 @@
 
 ## Usage
 
-     Usage: fis release [media name]
+```bash
 
-     Options:
+ [INFO] Currently running fis3 (/usr/local/lib/node_modules/fis3)
 
-       -d, --dest <names>     release output destination
-       -w, --watch            monitor the changes of project
-       -L, --live             automatically reload your browser
-       -c, --clean            clean compile cache
-       -u, --unique           use unique compile caching
+ Usage: fis3 release [media name]
+
+ Options:
+
+   -h, --help                print this help message
+   -d, --dest <path>         release output destination
+   -l, --lint                with lint
+   -w, --watch               monitor the changes of project
+   -L, --live                automatically reload your browser
+   -c, --clean               clean compile cache
+   -u, --unique              use unique compile caching
+   -r, --root <path>         specify project root
+   -f, --file <filename>     specify the file path of `fis-conf.js`
+   --no-color                disable colored output
+   --verbose                 enable verbose mode
+```

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 var _ = fis.util;
+var path = require('path');
 var watch = require('./lib/watch.js');
 var release = require('./lib/release.js');
 var deploy = require('./lib/deploy.js');
@@ -84,6 +85,27 @@ exports.run = function(argv, cli, env) {
   });
 
   options.live && app.use(livereload.checkReload);
+
+  // output fix
+  if (_.is(options['dest'], 'String')) {
+    var dest = path.resolve(fis.project.getProjectPath(), options['dest']);
+
+    if (dest && dest.indexOf(fis.project.getProjectPath()) === 0) {
+      fis.log.warn('skip `output` directory: ' + dest);
+      
+      // maybe fis.set('project.ignore', 'node_modules/**');
+      if (!_.is(fis.get('project.ignore'), 'Array')) {
+        fis.set('project.ignore', [fis.get('project.ignore')]);
+      }
+
+      fis.set(
+        'project.ignore',
+        fis.get('project.ignore').concat(
+          [dest.replace(fis.project.getProjectPath() + '/', '') + '/**']
+        )
+      );
+    }
+  }
 
   // run it.
   app.run(options);


### PR DESCRIPTION
通过长时间的使用，发现很多不看文档的同学，都会自己指定一个产出目录，导致递归编译。

```bash
.
└── resource
    ├── a
    │   └── resource
    │       ├── a
    │       │   └── resource
    │       │       ├── a_d41d8cd_d41d8cd_d41d8cd.js
    │       │       └── yarn.lock
    │       ├── a_d41d8cd_d41d8cd.js
    │       └── yarn.lock
    ├── a_d41d8cd.js
    └── yarn.lock
```

如上。

如果其产出目录为 a ，当 a 在 src 目录下时，就不再编译 a 下面的代码，并 WARN 提示。

```
 [WARNI] skip `output` directory: /Users/XXXX/Downloads/a
```